### PR TITLE
[BUG] Added assert to test_kriging_mutation

### DIFF
--- a/gempy/core/gempy_api.py
+++ b/gempy/core/gempy_api.py
@@ -145,12 +145,14 @@ def set_interpolator(geo_model: Model, output: list = None, compile_theano: bool
         compile_theano (bool): [s1]
         theano_optimizer (str {'fast_run', 'fast_compile'}): [s2]
         verbose:
-        kwargs:
-            -  pos_density (Optional[int]): Only necessary when type='grav'. Location on the Surfaces().df
-             where density is located (starting on id being 0).
-            - Vs
-            - pos_magnetics
-            -
+        update_kriging (bool): reset kriging values to its default.
+        update_structure (bool): sync Structure instance before setting theano graph.
+
+    Keyword Args:
+        -  pos_density (Optional[int]): Only necessary when type='grav'. Location on the Surfaces().df
+         where density is located (starting on id being 0).
+        - Vs
+        - pos_magnetics
 
     Returns:
 

--- a/test/test_core/test_integration.py
+++ b/test/test_core/test_integration.py
@@ -93,14 +93,18 @@ def test_kriging_mutation(interpolator_islith_isfault, map_sequential_pile):
     #plt.savefig(os.path.dirname(__file__)+'/figs/test_kriging_mutation')
 
     geo_model.modify_kriging_parameters('range', 1)
-
     geo_model.modify_kriging_parameters('drift equations', [0, 3])
-    print(geo_model.solutions.lith_block, geo_model.additional_data)
 
+    print(geo_model.solutions.lith_block, geo_model.additional_data)
+    # copy dataframe before interpolator is calculated
+    pre = geo_model.additional_data.kriging_data.df.copy()
+
+    gp.set_interpolation_data(geo_model, compile_theano=True,
+                    theano_optimizer='fast_compile')
     gp.compute_model(geo_model, compute_mesh=False)
     gp.plot.plot_scalar_field(geo_model, cell_number=25, series=1, N=15,
                               direction='y', show_data=True)
 
     print(geo_model.solutions.lith_block, geo_model.additional_data)
-   # plt.savefig(os.path.dirname(__file__)+'/figs/test_kriging_mutation2')
-
+    # plt.savefig(os.path.dirname(__file__)+'/figs/test_kriging_mutation2')
+    assert geo_model.additional_data.kriging_data.df['range'][0] == pre['range'][0]

--- a/test/test_core/test_integration.py
+++ b/test/test_core/test_integration.py
@@ -99,8 +99,8 @@ def test_kriging_mutation(interpolator_islith_isfault, map_sequential_pile):
     # copy dataframe before interpolator is calculated
     pre = geo_model.additional_data.kriging_data.df.copy()
 
-    gp.set_interpolation_data(geo_model, compile_theano=True,
-                    theano_optimizer='fast_compile')
+    gp.set_interpolator(geo_model, compile_theano=True,
+                        theano_optimizer='fast_compile', update_kriging=False)
     gp.compute_model(geo_model, compute_mesh=False)
     gp.plot.plot_scalar_field(geo_model, cell_number=25, series=1, N=15,
                               direction='y', show_data=True)


### PR DESCRIPTION
When using modify_kriging_parameters and recompiling the interpolator, the changes are not taken into account and reset to default.

# Description
We should be able to change the Covariance/Variogram range in the kriging interpolation. As of now changing the range parameter directly in the `model.additional_data` object or using `modify_kriging_parameter` is reset as soon as the interpolator is recompiled.
The test now checks if the range in the `additional_data` object is the same before and after recompiling. 

Relates to #322 

# Checklist
- [x] My code follows the [PEP 8 style guidelines](https://www.python.org/dev/peps/pep-0008/).
- [x] My code uses type hinting for function and method arguments and return values.
- [x] My code contains descriptive and helpful docstrings 
which are formatted per the [Google Python Style Guidelines](http://google.github.io/styleguide/pyguide.html).
- [x] I have created tests which entirely cover my code.
- [ ] The test code either 1. demonstrates at least one valuable use case (e.g. integration tests) 
or 2. verifies that outputs are as expected for given inputs (e.g. unit tests).
- [ ] New and existing tests pass locally with my changes.
 
