### PR TITLE
fix typo in set_custom_grid

### DIFF
--- a/gempy/core/model.py
+++ b/gempy/core/model.py
@@ -216,7 +216,7 @@ class DataMutation(object):
         if self.grid.custom_grid is None:
             self.grid.create_custom_grid(custom_grid)
         else:
-            self.grid.custom_grid.set_custmo_grid(custom_grid)
+            self.grid.custom_grid.set_custom_grid(custom_grid)
             self.grid.update_grid_values()
 
         self.update_from_grid()


### PR DESCRIPTION
# Description
found a typo in set_custom_grid, it was spelled "set_custmo_grid"

Relates to <issue>

# Checklist
- [x] My code follows the [PEP 8 style guidelines](https://www.python.org/dev/peps/pep-0008/).
- [ ] My code uses type hinting for function and method arguments and return values.
- [ ] My code contains descriptive and helpful docstrings 
which are formatted per the [Google Python Style Guidelines](http://google.github.io/styleguide/pyguide.html).
- [ ] I have created tests which entirely cover my code.
- [ ] The test code either 1. demonstrates at least one valuable use case (e.g. integration tests) 
or 2. verifies that outputs are as expected for given inputs (e.g. unit tests).
- [ ] New and existing tests pass locally with my changes.
 
