### PR TITLE
Added possibility to load data directly from pandas DataFrame objects instead of csv's

### DIFF
--- a/gempy/core/data.py
+++ b/gempy/core/data.py
@@ -1588,13 +1588,13 @@ class SurfacePoints(GeometricData):
         return self
 
     @setdoc_pro([ds.file_path, ds.debug, ds.inplace])
-    def read_surface_points(self, file_path, debug=False, inplace=False,
+    def read_surface_points(self, table_source, debug=False, inplace=False,
                             kwargs_pandas: dict = None, **kwargs, ):
         """
         Read tabular using pandas tools and if inplace set it properly to the surface points object.
 
         Parameters:
-            file_path (str, path object, or file-like object): [s0]
+            table_source (str, path object, file-like object or direct pandas data frame): [s0]
             debug (bool): [s1]
             inplace (bool): [s2]
             kwargs_pandas: kwargs for the panda function :func:`pn.read_csv`
@@ -1627,7 +1627,10 @@ class SurfacePoints(GeometricData):
         if 'sep' not in kwargs_pandas:
             kwargs_pandas['sep'] = ','
 
-        table = pn.read_csv(file_path, **kwargs_pandas)
+        if isinstance(table_source, pn.DataFrame):
+            table = table_source
+        else:
+            table = pn.read_csv(table_source, **kwargs_pandas)
 
         if 'update_surfaces' in kwargs:
             if kwargs['update_surfaces'] is True:
@@ -1986,12 +1989,12 @@ class Orientations(GeometricData):
                                  )
 
     @setdoc_pro([ds.file_path, ds.debug, ds.inplace])
-    def read_orientations(self, file_path, debug=False, inplace=True, kwargs_pandas: dict = None, **kwargs):
+    def read_orientations(self, table_source, debug=False, inplace=True, kwargs_pandas: dict = None, **kwargs):
         """
         Read tabular using pandas tools and if inplace set it properly to the surface points object.
 
         Args:
-            file_path (str, path object, or file-like object): [s0]
+            table_source (str, path object, file-like object, or direct data frame): [s0]
             debug (bool): [s1]
             inplace (bool): [s2]
             kwargs_pandas: kwargs for the panda function :func:`pn.read_csv`
@@ -2032,7 +2035,10 @@ class Orientations(GeometricData):
         if 'sep' not in kwargs_pandas:
             kwargs_pandas['sep'] = ','
 
-        table = pn.read_csv(file_path, **kwargs_pandas)
+        if isinstance(table_source, pn.DataFrame):
+            table = table_source
+        else:
+            table = pn.read_csv(table_source, **kwargs_pandas)
 
         if 'update_surfaces' in kwargs:
             if kwargs['update_surfaces'] is True:

--- a/gempy/core/gempy_api.py
+++ b/gempy/core/gempy_api.py
@@ -79,6 +79,14 @@ def read_csv(geo_model: Model, path_i=None, path_o=None, **kwargs):
     return True
 
 
+# region Point-Orientation functionality
+@setdoc([Model.read_data.__doc__])
+def read_df(geo_model: Model, df_i=None, df_o=None, **kwargs):
+    if df_i is not None or df_i is not None:
+        geo_model.read_data(df_i, df_o, **kwargs)
+    return True
+
+
 def set_orientation_from_surface_points(geo_model, indices_array):
     """
     Create and set orientations from at least 3 points of the :attr:`gempy.data_management.InputData.surface_points`
@@ -478,6 +486,8 @@ def init_data(geo_model: Model, extent: Union[list, ndarray] = None,
 
     if 'path_i' in kwargs or 'path_o' in kwargs:
         read_csv(geo_model, **kwargs)
+    if 'df_i' in kwargs or 'df_o' in kwargs:
+        read_df(geo_model, **kwargs)
 
     if 'surface_points_df' in kwargs:
         geo_model.set_surface_points(kwargs['surface_points_df'], **kwargs)

--- a/gempy/core/model.py
+++ b/gempy/core/model.py
@@ -1211,13 +1211,13 @@ class Model(DataMutation, ABC):
         return True
 
     @setdoc([SurfacePoints.read_surface_points.__doc__, Orientations.read_orientations.__doc__])
-    def read_data(self, path_i=None, path_o=None, add_basement=True, **kwargs):
+    def read_data(self, source_i=None, source_o=None, add_basement=True, **kwargs):
         """
-        Read data from a csv
+        Read data from a csv, or directly supplied dataframes
 
         Args:
-            path_i: Path to the data bases of surface_points. Default os.getcwd(),
-            path_o: Path to the data bases of orientations. Default os.getcwd()
+            source_i: Path to the data bases of surface_points. Default os.getcwd(), or direct pandas data frame
+            source_o: Path to the data bases of orientations. Default os.getcwd(), or direct pandas data frame
             add_basement (bool): if True add a basement surface. This wont be interpolated it just gives the values
             for the volume below the last surface.
             **kwargs:
@@ -1229,10 +1229,10 @@ class Model(DataMutation, ABC):
         if 'update_surfaces' not in kwargs:
             kwargs['update_surfaces'] = True
 
-        if path_i:
-            self.surface_points.read_surface_points(path_i, inplace=True, **kwargs)
-        if path_o:
-            self.orientations.read_orientations(path_o, inplace=True, **kwargs)
+        if source_i:
+            self.surface_points.read_surface_points(source_i, inplace=True, **kwargs)
+        if source_o:
+            self.orientations.read_orientations(source_o, inplace=True, **kwargs)
         if add_basement is True:
             self.surfaces.add_surface(['basement'])
             self.map_series_to_surfaces({'Basement': 'basement'}, set_series=True)

--- a/test/test_core/test_integration.py
+++ b/test/test_core/test_integration.py
@@ -31,6 +31,39 @@ def load_model():
     gp.get_data(geo_model, 'surface_points').head()
     return geo_model
 
+@pytest.fixture(scope="module")
+def load_model_df():
+
+    df_i = pn.DataFrame(np.random.randn(6,3), columns='X Y Z'.split())
+    df_i['formation'] = ['surface_1' for _ in range(3)] + ['surface_2' for _ in range(3)]
+
+    df_o = pn.DataFrame(np.random.randn(6,6), columns='X Y Z azimuth dip polarity'.split())
+    df_o['formation'] = ['surface_1' for _ in range(3)] + ['surface_2' for _ in range(3)]
+
+    geo_model = gp.create_model('test')
+    # Importing the data directly from the dataframes
+    gp.init_data(geo_model, [0, 2000., 0, 2000., 0, 2000.], [50 ,50 ,50],
+          df_o=df_o, df_i=df_i , default_values=True)
+
+    df_cmp_i = gp.get_data(geo_model, 'surface_points')
+    df_cmp_o = gp.get_data(geo_model, 'orientations')
+
+    assert np.any(np.isnan(df_cmp_i.values[:, :2])) is False, 'data was not set to dataframe'
+    assert np.any(np.isnan(df_cmp_o.values[:, :5])) is False, 'data was not set to dataframe'
+
+    geo_model = gp.create_model('test')
+    # Importing the data directly from the dataframes
+    gp.init_data(geo_model, [0, 2000., 0, 2000., 0, 2000.], [50 ,50 ,50],
+          df_o=df_o, df_i=df_i)
+
+    df_cmp_i2 = gp.get_data(geo_model, 'surface_points')
+    df_cmp_o2 = gp.get_data(geo_model, 'orientations')
+
+    assert np.any(np.isnan(df_cmp_i2.values[:, :2])) is False, 'data was not set to dataframe'
+    assert np.any(np.isnan(df_cmp_o2.values[:, :5])) is False, 'data was not set to dataframe'
+
+
+    return geo_model
 
 @pytest.fixture(scope='module')
 def map_sequential_pile(load_model):


### PR DESCRIPTION
# Description
Hi, 
I implemented a change that should allow to directly load data from passed pandas dataframe objects instead of loading it from csv files. This would be handy for a project I have where I need to import data directly from python objects.

# Checklist
- [x] My code follows the [PEP 8 style guidelines](https://www.python.org/dev/peps/pep-0008/).
- [x] My code uses type hinting for function and method arguments and return values.
- [x] My code contains descriptive and helpful docstrings 
which are formatted per the [Google Python Style Guidelines](http://google.github.io/styleguide/pyguide.html).
- [x] I have created tests which entirely cover my code.
- [x] The test code either 1. demonstrates at least one valuable use case (e.g. integration tests) 
or 2. verifies that outputs are as expected for given inputs (e.g. unit tests).
- [ ] New and existing tests pass locally with my changes.
--> Assembly fails to load locally atm because of pyvista dependency
