### PR TITLE
Added possibility to pass pandas dataframe objects directly to read_data()

### DIFF
--- a/gempy/core/data.py
+++ b/gempy/core/data.py
@@ -1588,13 +1588,13 @@ class SurfacePoints(GeometricData):
         return self
 
     @setdoc_pro([ds.file_path, ds.debug, ds.inplace])
-    def read_surface_points(self, file_path, debug=False, inplace=False,
+    def read_surface_points(self, table_source, debug=False, inplace=False,
                             kwargs_pandas: dict = None, **kwargs, ):
         """
         Read tabular using pandas tools and if inplace set it properly to the surface points object.
 
         Parameters:
-            file_path (str, path object, or file-like object): [s0]
+            table_source (str, path object, file-like object or direct pandas data frame): [s0]
             debug (bool): [s1]
             inplace (bool): [s2]
             kwargs_pandas: kwargs for the panda function :func:`pn.read_csv`
@@ -1627,7 +1627,10 @@ class SurfacePoints(GeometricData):
         if 'sep' not in kwargs_pandas:
             kwargs_pandas['sep'] = ','
 
-        table = pn.read_csv(file_path, **kwargs_pandas)
+        if isinstance(table_source, pn.DataFrame):
+            table = table_source
+        else:
+            table = pn.read_csv(table_source, **kwargs_pandas)
 
         if 'update_surfaces' in kwargs:
             if kwargs['update_surfaces'] is True:
@@ -1986,12 +1989,12 @@ class Orientations(GeometricData):
                                  )
 
     @setdoc_pro([ds.file_path, ds.debug, ds.inplace])
-    def read_orientations(self, file_path, debug=False, inplace=True, kwargs_pandas: dict = None, **kwargs):
+    def read_orientations(self, table_source, debug=False, inplace=True, kwargs_pandas: dict = None, **kwargs):
         """
         Read tabular using pandas tools and if inplace set it properly to the surface points object.
 
         Args:
-            file_path (str, path object, or file-like object): [s0]
+            table_source (str, path object, file-like object, or direct data frame): [s0]
             debug (bool): [s1]
             inplace (bool): [s2]
             kwargs_pandas: kwargs for the panda function :func:`pn.read_csv`
@@ -2032,7 +2035,10 @@ class Orientations(GeometricData):
         if 'sep' not in kwargs_pandas:
             kwargs_pandas['sep'] = ','
 
-        table = pn.read_csv(file_path, **kwargs_pandas)
+        if isinstance(table_source, pn.DataFrame):
+            table = table_source
+        else:
+            table = pn.read_csv(table_source, **kwargs_pandas)
 
         if 'update_surfaces' in kwargs:
             if kwargs['update_surfaces'] is True:

--- a/gempy/core/data.py
+++ b/gempy/core/data.py
@@ -1579,12 +1579,6 @@ class SurfacePoints(GeometricData):
         # Selecting the properties passed to be modified
         self.df.loc[idx, list(kwargs.keys())] = values
 
-        # if is_surface:
-        #     self.map_data_from_surfaces(self.surfaces, 'series', idx=idx)
-        #     self.map_data_from_surfaces(self.surfaces, 'id', idx=idx)
-        #     self.map_data_from_series(self.surfaces.series, 'order_series', idx=idx)
-        #     self.sort_table()
-
         return self
 
     @setdoc_pro([ds.file_path, ds.debug, ds.inplace])

--- a/gempy/core/gempy_api.py
+++ b/gempy/core/gempy_api.py
@@ -509,8 +509,6 @@ def init_data(geo_model: Model, extent: Union[list, ndarray] = None,
 
     if 'path_i' in kwargs or 'path_o' in kwargs:
         read_csv(geo_model, **kwargs)
-    if 'df_i' in kwargs or 'df_o' in kwargs:
-        set_geometric_data(geo_model, **kwargs)
 
     if 'surface_points_df' in kwargs:
         geo_model.set_surface_points(kwargs['surface_points_df'], **kwargs)

--- a/gempy/core/gempy_api.py
+++ b/gempy/core/gempy_api.py
@@ -80,11 +80,34 @@ def read_csv(geo_model: Model, path_i=None, path_o=None, **kwargs):
 
 
 # region Point-Orientation functionality
-@setdoc([Model.read_data.__doc__])
-def read_df(geo_model: Model, df_i=None, df_o=None, **kwargs):
-    if df_i is not None or df_i is not None:
-        geo_model.read_data(df_i, df_o, **kwargs)
-    return True
+@setdoc_pro([Model.__doc__])
+def set_geometric_data(geo_model: Model, surface_points_df=None, orientations_df=None, **kwargs):
+    """ Function to set directly pandas.Dataframes to the gempy geometric data objects
+
+    Args:
+        geo_model: [s0]
+        surface_points_df:  A pn.Dataframe object with X, Y, Z, and surface columns
+        orientations_df: A pn.Dataframe object with X, Y, Z, surface columns and pole or orientation columns
+        **kwargs:
+
+    Returns:
+        Modified df
+    """
+
+    r_ = None
+
+    if surface_points_df is not None:
+        geo_model.set_surface_points(surface_points_df, **kwargs)
+        r_ = 'surface_points'
+
+    elif orientations_df is not None:
+        geo_model.set_orientations(orientations_df, **kwargs)
+        r_ = 'data' if r_ == 'surface_points' else 'orientations'
+
+    else:
+        raise AttributeError('You need to pass at least one dataframe')
+
+    return get_data(geo_model, itype=r_)
 
 
 def set_orientation_from_surface_points(geo_model, indices_array):
@@ -471,8 +494,8 @@ def init_data(geo_model: Model, extent: Union[list, ndarray] = None,
 
         path_i: Path to the data bases of surface_points. Default os.getcwd(),
         path_o: Path to the data bases of orientations. Default os.getcwd()
-        surface_points_df: A df object directly
-        orientations_df:
+        surface_points_df: A pn.Dataframe object with X, Y, Z, and surface columns
+        orientations_df: A pn.Dataframe object with X, Y, Z, surface columns and pole or orientation columns
 
     Returns:
         :class:`gempy.data_management.InputData`
@@ -487,7 +510,7 @@ def init_data(geo_model: Model, extent: Union[list, ndarray] = None,
     if 'path_i' in kwargs or 'path_o' in kwargs:
         read_csv(geo_model, **kwargs)
     if 'df_i' in kwargs or 'df_o' in kwargs:
-        read_df(geo_model, **kwargs)
+        set_geometric_data(geo_model, **kwargs)
 
     if 'surface_points_df' in kwargs:
         geo_model.set_surface_points(kwargs['surface_points_df'], **kwargs)

--- a/gempy/core/gempy_api.py
+++ b/gempy/core/gempy_api.py
@@ -79,6 +79,14 @@ def read_csv(geo_model: Model, path_i=None, path_o=None, **kwargs):
     return True
 
 
+# region Point-Orientation functionality
+@setdoc([Model.read_data.__doc__])
+def read_df(geo_model: Model, df_i=None, df_o=None, **kwargs):
+    if df_i is not None or df_i is not None:
+        geo_model.read_data(df_i, df_o, **kwargs)
+    return True
+
+
 def set_orientation_from_surface_points(geo_model, indices_array):
     """
     Create and set orientations from at least 3 points of the :attr:`gempy.data_management.InputData.surface_points`
@@ -478,6 +486,8 @@ def init_data(geo_model: Model, extent: Union[list, ndarray] = None,
 
     if 'path_i' in kwargs or 'path_o' in kwargs:
         read_csv(geo_model, **kwargs)
+    if 'df_i' in kwargs or 'df_o' in kwargs:
+        read_df(geo_model, **kwargs)
 
     if 'surface_points_df' in kwargs:
         geo_model.set_surface_points(kwargs['surface_points_df'], **kwargs)

--- a/gempy/core/model.py
+++ b/gempy/core/model.py
@@ -589,6 +589,11 @@ class DataMutation(object):
     def set_surface_points_object(self, surface_points: SurfacePoints, update_model=True):
         raise NotImplementedError
 
+    @staticmethod
+    def _check_possible_column_names(table, possible_candidates):
+        possible_candidates = np.array(possible_candidates)
+        return possible_candidates[np.isin(possible_candidates, table.columns)][0]
+
     @setdoc(SurfacePoints.set_surface_points.__doc__, indent=False, position='beg')
     def set_surface_points(self, table: pn.DataFrame, **kwargs):
         """
@@ -598,10 +603,16 @@ class DataMutation(object):
                 - add_basement (bool): add a basement surface to the df. foo
 
         """
-        coord_x_name = kwargs.get('coord_x_name', "X")
-        coord_y_name = kwargs.get('coord_y_name', "Y")
-        coord_z_name = kwargs.get('coord_z_name', "Z")
-        surface_name = kwargs.get('surface_name', "surface")
+
+        coord_x_name = kwargs.get('coord_x_name') if 'coord_x_name' in kwargs \
+            else self._check_possible_column_names(table, ['X', 'x'])
+        coord_y_name =kwargs.get('coord_y_name') if 'coord_y_name' in kwargs \
+            else self._check_possible_column_names(table, ['Y', 'y'])
+        coord_z_name = kwargs.get('coord_z_name') if 'coord_z_name' in kwargs \
+            else self._check_possible_column_names(table, ['Z', 'z'])
+        surface_name = kwargs.get('surface_name') if 'surface_name' in kwargs \
+            else self._check_possible_column_names(table, ['surface', 'Surface', 'surfaces', 'surfaces', 'formations',
+                                                           'formation'])
         update_surfaces = kwargs.get('update_surfaces', True)
 
         if update_surfaces is True:
@@ -629,17 +640,23 @@ class DataMutation(object):
             table (pn.Dataframe): table with surface points data.
 
         """
-        coord_x_name = kwargs.get('coord_x_name', "X")
-        coord_y_name = kwargs.get('coord_y_name', "Y")
-        coord_z_name = kwargs.get('coord_z_name', "Z")
         g_x_name = kwargs.get('G_x_name', 'G_x')
         g_y_name = kwargs.get('G_y_name', 'G_y')
         g_z_name = kwargs.get('G_z_name', 'G_z')
         azimuth_name = kwargs.get('azimuth_name', 'azimuth')
         dip_name = kwargs.get('dip_name', 'dip')
         polarity_name = kwargs.get('polarity_name', 'polarity')
-        surface_name = kwargs.get('surface_name', "formation")
         update_surfaces = kwargs.get('update_surfaces', False)
+
+        coord_x_name = kwargs.get('coord_x_name') if 'coord_x_name' in kwargs \
+            else self._check_possible_column_names(table, ['X', 'x'])
+        coord_y_name = kwargs.get('coord_y_name') if 'coord_y_name' in kwargs \
+            else self._check_possible_column_names(table, ['Y', 'y'])
+        coord_z_name = kwargs.get('coord_z_name') if 'coord_z_name' in kwargs \
+            else self._check_possible_column_names(table, ['Z', 'z'])
+        surface_name = kwargs.get('surface_name') if 'surface_name' in kwargs \
+            else self._check_possible_column_names(table, ['surface', 'Surface', 'surfaces', 'surfaces', 'formations',
+                                                           'formation', 'Formation'])
 
         if update_surfaces is True:
             self.add_surfaces(table[surface_name].unique())

--- a/gempy/core/model.py
+++ b/gempy/core/model.py
@@ -1229,9 +1229,9 @@ class Model(DataMutation, ABC):
         if 'update_surfaces' not in kwargs:
             kwargs['update_surfaces'] = True
 
-        if source_i:
+        if isinstance(source_i, pn.DataFrame) or source_i:
             self.surface_points.read_surface_points(source_i, inplace=True, **kwargs)
-        if source_o:
+        if isinstance(source_o, pn.DataFrame) or source_o:
             self.orientations.read_orientations(source_o, inplace=True, **kwargs)
         if add_basement is True:
             self.surfaces.add_surface(['basement'])

--- a/gempy/core/model.py
+++ b/gempy/core/model.py
@@ -1211,13 +1211,13 @@ class Model(DataMutation, ABC):
         return True
 
     @setdoc([SurfacePoints.read_surface_points.__doc__, Orientations.read_orientations.__doc__])
-    def read_data(self, path_i=None, path_o=None, add_basement=True, **kwargs):
+    def read_data(self, source_i=None, source_o=None, add_basement=True, **kwargs):
         """
-        Read data from a csv
+        Read data from a csv, or directly supplied dataframes
 
         Args:
-            path_i: Path to the data bases of surface_points. Default os.getcwd(),
-            path_o: Path to the data bases of orientations. Default os.getcwd()
+            source_i: Path to the data bases of surface_points. Default os.getcwd(), or direct pandas data frame
+            source_o: Path to the data bases of orientations. Default os.getcwd(), or direct pandas data frame
             add_basement (bool): if True add a basement surface. This wont be interpolated it just gives the values
             for the volume below the last surface.
             **kwargs:
@@ -1229,10 +1229,10 @@ class Model(DataMutation, ABC):
         if 'update_surfaces' not in kwargs:
             kwargs['update_surfaces'] = True
 
-        if path_i:
-            self.surface_points.read_surface_points(path_i, inplace=True, **kwargs)
-        if path_o:
-            self.orientations.read_orientations(path_o, inplace=True, **kwargs)
+        if source_i:
+            self.surface_points.read_surface_points(source_i, inplace=True, **kwargs)
+        if source_o:
+            self.orientations.read_orientations(source_o, inplace=True, **kwargs)
         if add_basement is True:
             self.surfaces.add_surface(['basement'])
             self.map_series_to_surfaces({'Basement': 'basement'}, set_series=True)

--- a/test/test_core/test_integration.py
+++ b/test/test_core/test_integration.py
@@ -58,7 +58,7 @@ def test_load_model_df():
     geo_model = gp.create_model('test')
     # Importing the data directly from the dataframes
     gp.init_data(geo_model, [0, 2000., 0, 2000., 0, 2000.], [50, 50, 50],
-                 df_o=df_o, df_i=df_i , default_values=True)
+                 surface_points_df=df_i, orientations_df=df_o, default_values=True)
 
     df_cmp_i = gp.get_data(geo_model, 'surface_points')
     df_cmp_o = gp.get_data(geo_model, 'orientations')
@@ -71,36 +71,6 @@ def test_load_model_df():
     assert not df_cmp_o.empty, 'data was not set to dataframe'
     assert df_cmp_i.shape[0] == 6, 'data was not set to dataframe'
     assert df_cmp_o.shape[0] == 6, 'data was not set to dataframe'
-
-    # try without the default_values command
-
-    geo_model = gp.create_model('test')
-    # Importing the data directly from the dataframes
-    gp.init_data(geo_model, [0, 2000., 0, 2000., 0, 2000.], [50 ,50 ,50],
-                 df_o=df_o, df_i=df_i)
-
-    df_cmp_i2 = gp.get_data(geo_model, 'surface_points')
-    df_cmp_o2 = gp.get_data(geo_model, 'orientations')
-
-    if verbose:
-        print(df_cmp_i2.head())
-        print(df_cmp_o2.head())
-
-    assert not df_cmp_i2.empty, 'data was not set to dataframe'
-    assert not df_cmp_o2.empty, 'data was not set to dataframe'
-    assert df_cmp_i2.shape[0] == 6, 'data was not set to dataframe'
-    assert df_cmp_o2.shape[0] == 6, 'data was not set to dataframe'
-
-    return geo_model
-
-
-def test_load_model_df_2():
-    verbose = True
-    df_i = pn.DataFrame(np.random.randn(6,3), columns='X Y Z'.split())
-    df_i['formation'] = ['surface_1' for _ in range(3)] + ['surface_2' for _ in range(3)]
-
-    df_o = pn.DataFrame(np.random.randn(6,6), columns='X Y Z azimuth dip polarity'.split())
-    df_o['formation'] = ['surface_1' for _ in range(3)] + ['surface_2' for _ in range(3)]
 
     # try without the default_values command
 
@@ -122,7 +92,6 @@ def test_load_model_df_2():
     assert df_cmp_o2.shape[0] == 6, 'data was not set to dataframe'
 
     return geo_model
-
 
 
 @pytest.fixture(scope='module')

--- a/test/test_core/test_integration.py
+++ b/test/test_core/test_integration.py
@@ -26,8 +26,8 @@ def load_model():
 
     # Importing the data from CSV-files and setting extent and resolution
     gp.init_data(geo_model, [0, 2000., 0, 2000., 0, 2000.], [50 ,50 ,50],
-          path_o = input_path+"/simple_fault_model_orientations.csv",
-          path_i = input_path+"/simple_fault_model_points.csv", default_values=True)
+                 path_o=input_path+"/simple_fault_model_orientations.csv",
+                 path_i=input_path+"/simple_fault_model_points.csv", default_values=True)
 
     df_cmp_i = gp.get_data(geo_model, 'surface_points')
     df_cmp_o = gp.get_data(geo_model, 'orientations')
@@ -48,7 +48,7 @@ def load_model():
 
 def test_load_model_df():
 
-    verbose = False
+    verbose = True
     df_i = pn.DataFrame(np.random.randn(6,3), columns='X Y Z'.split())
     df_i['formation'] = ['surface_1' for _ in range(3)] + ['surface_2' for _ in range(3)]
 
@@ -58,7 +58,7 @@ def test_load_model_df():
     geo_model = gp.create_model('test')
     # Importing the data directly from the dataframes
     gp.init_data(geo_model, [0, 2000., 0, 2000., 0, 2000.], [50, 50, 50],
-          df_o=df_o, df_i=df_i , default_values=True)
+                 df_o=df_o, df_i=df_i , default_values=True)
 
     df_cmp_i = gp.get_data(geo_model, 'surface_points')
     df_cmp_o = gp.get_data(geo_model, 'orientations')
@@ -77,7 +77,7 @@ def test_load_model_df():
     geo_model = gp.create_model('test')
     # Importing the data directly from the dataframes
     gp.init_data(geo_model, [0, 2000., 0, 2000., 0, 2000.], [50 ,50 ,50],
-          df_o=df_o, df_i=df_i)
+                 df_o=df_o, df_i=df_i)
 
     df_cmp_i2 = gp.get_data(geo_model, 'surface_points')
     df_cmp_o2 = gp.get_data(geo_model, 'orientations')
@@ -92,6 +92,55 @@ def test_load_model_df():
     assert df_cmp_o2.shape[0] == 6, 'data was not set to dataframe'
 
     return geo_model
+
+
+def test_load_model_df_2():
+    verbose = True
+    df_i = pn.DataFrame(np.random.randn(6,3), columns='X Y Z'.split())
+    df_i['formation'] = ['surface_1' for _ in range(3)] + ['surface_2' for _ in range(3)]
+
+    df_o = pn.DataFrame(np.random.randn(6,6), columns='X Y Z azimuth dip polarity'.split())
+    df_o['formation'] = ['surface_1' for _ in range(3)] + ['surface_2' for _ in range(3)]
+
+    geo_model = gp.create_model('test')
+    # Importing the data directly from the dataframes
+    gp.init_data(geo_model, [0, 2000., 0, 2000., 0, 2000.], [50, 50, 50],
+                 df_o=df_o, df_i=df_i , default_values=True)
+
+    df_cmp_i = gp.get_data(geo_model, 'surface_points')
+    df_cmp_o = gp.get_data(geo_model, 'orientations')
+
+    if verbose:
+        print(df_cmp_i.head())
+        print(df_cmp_o.head())
+
+    assert not df_cmp_i.empty, 'data was not set to dataframe'
+    assert not df_cmp_o.empty, 'data was not set to dataframe'
+    assert df_cmp_i.shape[0] == 6, 'data was not set to dataframe'
+    assert df_cmp_o.shape[0] == 6, 'data was not set to dataframe'
+
+    # try without the default_values command
+
+    geo_model = gp.create_model('test')
+    # Importing the data directly from the dataframes
+    gp.init_data(geo_model, [0, 2000., 0, 2000., 0, 2000.], [50 ,50 ,50],
+                 surface_points_df=df_i, orientations_df=df_i)
+
+    df_cmp_i2 = gp.get_data(geo_model, 'surface_points')
+    df_cmp_o2 = gp.get_data(geo_model, 'orientations')
+
+    if verbose:
+        print(df_cmp_i2.head())
+        print(df_cmp_o2.head())
+
+    assert not df_cmp_i2.empty, 'data was not set to dataframe'
+    assert not df_cmp_o2.empty, 'data was not set to dataframe'
+    assert df_cmp_i2.shape[0] == 6, 'data was not set to dataframe'
+    assert df_cmp_o2.shape[0] == 6, 'data was not set to dataframe'
+
+    return geo_model
+
+
 
 @pytest.fixture(scope='module')
 def map_sequential_pile(load_model):

--- a/test/test_core/test_integration.py
+++ b/test/test_core/test_integration.py
@@ -31,6 +31,39 @@ def load_model():
     gp.get_data(geo_model, 'surface_points').head()
     return geo_model
 
+@pytest.fixture(scope="module")
+def load_model_df():
+
+    df_i = pn.DataFrame(np.random.randn(6,3), columns='X Y Z'.split())
+    df_i['formation'] = ['surface_1' for _ in range(3)] + ['surface_2' for _ in range(3)]
+
+    df_o = pn.DataFrame(np.random.randn(6,6), columns='X Y Z azimuth dip polarity'.split())
+    df_o['formation'] = ['surface_1' for _ in range(3)] + ['surface_2' for _ in range(3)]
+
+    geo_model = gp.create_model('test')
+    # Importing the data directly from the dataframes
+    gp.init_data(geo_model, [0, 2000., 0, 2000., 0, 2000.], [50 ,50 ,50],
+          df_o=df_o, df_i=df_i , default_values=True)
+
+    df_cmp_i = gp.get_data(geo_model, 'surface_points')
+    df_cmp_o = gp.get_data(geo_model, 'orientations')
+
+    assert np.any(np.isnan(df_cmp_i.values[:, :2])) is False, 'data was not set to dataframe'
+    assert np.any(np.isnan(df_cmp_o.values[:, :5])) is False, 'data was not set to dataframe'
+
+    geo_model = gp.create_model('test')
+    # Importing the data directly from the dataframes
+    gp.init_data(geo_model, [0, 2000., 0, 2000., 0, 2000.], [50 ,50 ,50],
+          df_o=df_o, df_i=df_i)
+
+    df_cmp_i2 = gp.get_data(geo_model, 'surface_points')
+    df_cmp_o2 = gp.get_data(geo_model, 'orientations')
+
+    assert np.any(np.isnan(df_cmp_i2.values[:, :2])) is False, 'data was not set to dataframe'
+    assert np.any(np.isnan(df_cmp_o2.values[:, :5])) is False, 'data was not set to dataframe'
+
+
+    return geo_model
 
 @pytest.fixture(scope='module')
 def map_sequential_pile(load_model):

--- a/test/test_core/test_integration.py
+++ b/test/test_core/test_integration.py
@@ -21,6 +21,7 @@ sys.path.append("../..")
 
 @pytest.fixture(scope="module")
 def load_model():
+    verbose = False
     geo_model = gp.create_model('Model_Tuto1-1')
 
     # Importing the data from CSV-files and setting extent and resolution
@@ -28,12 +29,26 @@ def load_model():
           path_o = input_path+"/simple_fault_model_orientations.csv",
           path_i = input_path+"/simple_fault_model_points.csv", default_values=True)
 
-    gp.get_data(geo_model, 'surface_points').head()
+    df_cmp_i = gp.get_data(geo_model, 'surface_points')
+    df_cmp_o = gp.get_data(geo_model, 'orientations')
+
+    df_o = pn.read_csv(input_path + "/simple_fault_model_orientations.csv")
+    df_i = pn.read_csv(input_path + "/simple_fault_model_points.csv")
+
+    assert not df_cmp_i.empty, 'data was not set to dataframe'
+    assert not df_cmp_o.empty, 'data was not set to dataframe'
+    assert df_cmp_i.shape[0] == df_i.shape[0], 'data was not set to dataframe'
+    assert df_cmp_o.shape[0] == df_o.shape[0], 'data was not set to dataframe'
+
+    if verbose:
+        gp.get_data(geo_model, 'surface_points').head()
+
     return geo_model
 
-@pytest.fixture(scope="module")
-def load_model_df():
 
+def test_load_model_df():
+
+    verbose = False
     df_i = pn.DataFrame(np.random.randn(6,3), columns='X Y Z'.split())
     df_i['formation'] = ['surface_1' for _ in range(3)] + ['surface_2' for _ in range(3)]
 
@@ -42,14 +57,22 @@ def load_model_df():
 
     geo_model = gp.create_model('test')
     # Importing the data directly from the dataframes
-    gp.init_data(geo_model, [0, 2000., 0, 2000., 0, 2000.], [50 ,50 ,50],
+    gp.init_data(geo_model, [0, 2000., 0, 2000., 0, 2000.], [50, 50, 50],
           df_o=df_o, df_i=df_i , default_values=True)
 
     df_cmp_i = gp.get_data(geo_model, 'surface_points')
     df_cmp_o = gp.get_data(geo_model, 'orientations')
 
-    assert np.any(np.isnan(df_cmp_i.values[:, :2])) is False, 'data was not set to dataframe'
-    assert np.any(np.isnan(df_cmp_o.values[:, :5])) is False, 'data was not set to dataframe'
+    if verbose:
+        print(df_cmp_i.head())
+        print(df_cmp_o.head())
+
+    assert not df_cmp_i.empty, 'data was not set to dataframe'
+    assert not df_cmp_o.empty, 'data was not set to dataframe'
+    assert df_cmp_i.shape[0] == 6, 'data was not set to dataframe'
+    assert df_cmp_o.shape[0] == 6, 'data was not set to dataframe'
+
+    # try without the default_values command
 
     geo_model = gp.create_model('test')
     # Importing the data directly from the dataframes
@@ -59,9 +82,14 @@ def load_model_df():
     df_cmp_i2 = gp.get_data(geo_model, 'surface_points')
     df_cmp_o2 = gp.get_data(geo_model, 'orientations')
 
-    assert np.any(np.isnan(df_cmp_i2.values[:, :2])) is False, 'data was not set to dataframe'
-    assert np.any(np.isnan(df_cmp_o2.values[:, :5])) is False, 'data was not set to dataframe'
+    if verbose:
+        print(df_cmp_i2.head())
+        print(df_cmp_o2.head())
 
+    assert not df_cmp_i2.empty, 'data was not set to dataframe'
+    assert not df_cmp_o2.empty, 'data was not set to dataframe'
+    assert df_cmp_i2.shape[0] == 6, 'data was not set to dataframe'
+    assert df_cmp_o2.shape[0] == 6, 'data was not set to dataframe'
 
     return geo_model
 

--- a/test/test_core/test_integration.py
+++ b/test/test_core/test_integration.py
@@ -102,29 +102,12 @@ def test_load_model_df_2():
     df_o = pn.DataFrame(np.random.randn(6,6), columns='X Y Z azimuth dip polarity'.split())
     df_o['formation'] = ['surface_1' for _ in range(3)] + ['surface_2' for _ in range(3)]
 
-    geo_model = gp.create_model('test')
-    # Importing the data directly from the dataframes
-    gp.init_data(geo_model, [0, 2000., 0, 2000., 0, 2000.], [50, 50, 50],
-                 df_o=df_o, df_i=df_i , default_values=True)
-
-    df_cmp_i = gp.get_data(geo_model, 'surface_points')
-    df_cmp_o = gp.get_data(geo_model, 'orientations')
-
-    if verbose:
-        print(df_cmp_i.head())
-        print(df_cmp_o.head())
-
-    assert not df_cmp_i.empty, 'data was not set to dataframe'
-    assert not df_cmp_o.empty, 'data was not set to dataframe'
-    assert df_cmp_i.shape[0] == 6, 'data was not set to dataframe'
-    assert df_cmp_o.shape[0] == 6, 'data was not set to dataframe'
-
     # try without the default_values command
 
     geo_model = gp.create_model('test')
     # Importing the data directly from the dataframes
     gp.init_data(geo_model, [0, 2000., 0, 2000., 0, 2000.], [50 ,50 ,50],
-                 surface_points_df=df_i, orientations_df=df_i)
+                 surface_points_df=df_i, orientations_df=df_o)
 
     df_cmp_i2 = gp.get_data(geo_model, 'surface_points')
     df_cmp_o2 = gp.get_data(geo_model, 'orientations')


### PR DESCRIPTION
# Description
I implemented a feature, where pandas dataframe objects can be passed directly to read_data method. This is helpful for a project I am working on, where gempy needs to be integrated in another framework

# Checklist
- [x] My code follows the [PEP 8 style guidelines](https://www.python.org/dev/peps/pep-0008/).
- [x] My code uses type hinting for function and method arguments and return values.
- [x] My code contains descriptive and helpful docstrings 
which are formatted per the [Google Python Style Guidelines](http://google.github.io/styleguide/pyguide.html).
- [x] I have created tests which entirely cover my code.
- [x] The test code either 1. demonstrates at least one valuable use case (e.g. integration tests) 
or 2. verifies that outputs are as expected for given inputs (e.g. unit tests).
- [x] New and existing tests pass locally with my changes.
 
