### PR TITLE
Fix pyvistaqt deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,9 @@ install:
   - source activate tenv
 
   # Installs from conda-forge
-  - conda install -c conda-forge python-graphviz emg3d discretize pip matplotlib ipython six pytest pytest-cov pytest-mock gdal pandas seaborn>=0.9 qgrid sphinx-gallery ipywidgets pyevtk arviz dataclasses scikit-image>=0.17 recommonmark networkx panel setuptools
+  - conda install -c conda-forge python-graphviz emg3d discretize pip matplotlib ipython six pytest pytest-cov pytest-mock
+    gdal pandas seaborn>=0.9 qgrid sphinx-gallery ipywidgets pyevtk arviz dataclasses scikit-image>=0.17 recommonmark
+    networkx panel setuptools mkl-service
 
   # Installs from anaconda
   - conda install -c anaconda libffi

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
   include:
       - stage: test
         script:
-          - pytest
+          - pytest -v
       - stage: deploy
         name: Deploy to GitHub Pages
        # if: (NOT type IN (pull_request)) AND (branch = sphinx-gallery) # only deploy if merging on master

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ install:
   # Install
   - pip install -e .
 
+  - python -c "import pyvista as pv;print(pv.Report())"
+
 stages:
   - test
   - deploy

--- a/gempy/__init__.py
+++ b/gempy/__init__.py
@@ -7,6 +7,15 @@ Created on 21/10/2016
 import sys
 import os
 
+import warnings
+
+try:
+    import faulthandler
+    faulthandler.enable()
+except Exception as e:  # pragma: no cover
+    warnings.warn('Unable to enable faulthandler:\n%s' % str(e))
+
+
 PACKAGE_PARENT = '..'
 SCRIPT_DIR = os.path.dirname(os.path.realpath(os.path.join(os.getcwd(), os.path.expanduser(__file__))))
 sys.path.append(os.path.normpath(os.path.join(SCRIPT_DIR, PACKAGE_PARENT)))

--- a/gempy/plot/_vista.py
+++ b/gempy/plot/_vista.py
@@ -35,6 +35,7 @@ import numpy as np
 import pandas as pn
 try:
     import pyvista as pv
+    import pyvistaqt as pvqt
     from pyvista.plotting.theme import parse_color
     PYVISTA_IMPORT = True
 except ImportError:
@@ -88,7 +89,7 @@ class __Vista:
         if plotter_type == 'basic':
             self.p = pv.Plotter(**kwargs)
         elif plotter_type == 'background':
-            self.p = pv.BackgroundPlotter(**kwargs)
+            self.p = pvqt.BackgroundPlotter(**kwargs)
 
         self.set_bounds()
         self.p.view_isometric(negative=False)
@@ -469,7 +470,7 @@ class Vista:
         if plotter_type == 'basic':
             self.p = pv.Plotter(**kwargs)
         elif plotter_type == 'background':
-            self.p = pv.BackgroundPlotter(**kwargs)
+            self.p = pvqt.BackgroundPlotter(**kwargs)
 
         self._surface_actors = {}
         self._surface_points_actors = {}

--- a/gempy/plot/vista.py
+++ b/gempy/plot/vista.py
@@ -38,6 +38,7 @@ import pandas as pd
 # TODO Check if this is necessary if it is implemented in the API
 try:
     import pyvista as pv
+    import pyvistaqt as pvqt
     from pyvista.plotting.theme import parse_color
 
     PYVISTA_IMPORT = True
@@ -97,11 +98,7 @@ class GemPyToVista(WidgetsCallbacks, RenderChanges):
             raise NotImplementedError
             # self.p = pv.PlotterITK()
         elif plotter_type == 'background':
-            try:
-                from pyvistaqt import BackgroundPlotter
-                self.p = BackgroundPlotter(**kwargs)
-            except ImportError:
-                self.p = pv.BackgroundPlotter(**kwargs)
+            self.p = pvqt.BackgroundPlotter(**kwargs)
             self.p.view_isometric(negative=False)
         else:
             raise AttributeError('Plotter type must be basic, background or notebook.')

--- a/gempy/plot/vista_qt.py
+++ b/gempy/plot/vista_qt.py
@@ -1,4 +1,5 @@
 import pyvista as pv
+import pyvistaqt as pvqt
 from PyQt5.QtCore import *
 from PyQt5.QtGui import *
 from PyQt5.QtWidgets import *
@@ -39,7 +40,7 @@ class MainWidget(QWidget):
         plot = QFrame()
         self.Vista = Vista(geo_model,
                            plotter_type="basic")  # init Vista plotter
-        self.vtk_widget = pv.QtInteractor(plot)
+        self.vtk_widget = pvqt.QtInteractor(plot)
         self.Vista.p = self.vtk_widget  # set Plotter to the vtk widget Plotter
 
         splitter.addWidget(self.vtk_widget)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ pytest
 seaborn>=0.9
 networkx
 scikit-image>=0.17
-pyvista
+pyvista>=0.25
 iPython
 pyvistaqt

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,9 @@ setup(
         'seaborn>=0.9',
         'networkx',
         'scikit-image>=0.17',
-        'pyvista',
+        'pyvista>=0.25',
+        'pyvistaqt',
         'iPython',
-        'pyvistaqt'
     ],
     url='https://github.com/cgre-aachen/gempy',
     download_url='https://github.com/cgre-aachen/gempy/archive/2.1.1tar.gz',

--- a/test/test_core/test_grids/test_topography.py
+++ b/test/test_core/test_grids/test_topography.py
@@ -1,8 +1,15 @@
 import os
 import sys, os
 sys.path.append("../../..")
-os.environ['CUDA_LAUNCH_BLOCKING'] = '1'
+
 os.environ["THEANO_FLAGS"] = "mode=FAST_RUN,device=cpu"
+import warnings
+
+try:
+    import faulthandler
+    faulthandler.enable()
+except Exception as e:  # pragma: no cover
+    warnings.warn('Unable to enable faulthandler:\n%s' % str(e))
 
 import gempy as gp
 import matplotlib.pyplot as plt


### PR DESCRIPTION
# Description

Follow up to 063c06371af9c8efb317d69fee8cd744fd9e096d

This sets a minimum version for PyVista since the `pyvistaqt` dependency was added in 063c06371af9c8efb317d69fee8cd744fd9e096d

No reason to have try/excepts for different pyvista versions if you have `pyvistaqt` as a hard dependency

# Checklist

I did not run any of this locally. The diff is small and CI's should catch any serious issues.
 
