### PR TITLE
update setup.py to remove import of gempy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
         'pyvistaqt'
     ],
     url='https://github.com/cgre-aachen/gempy',
-    download_url='https://github.com/cgre-aachen/gempy/archive/2.2.1.tar.gz',
     license='LGPL v3',
     author='Miguel de la Varga, Elisa Heim, Alexander Schaaf, Fabian Stamm, Florian Wellmann',
     author_email='varga@aices.rwth-aachen.de',

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,11 @@
 from setuptools import setup, find_packages
-from gempy import __version__
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(
     name='gempy',
-    version=__version__,
+    version='2.2.1',
     packages=find_packages(exclude=('test', 'docs')),
     include_package_data=True,
     install_requires=[
@@ -23,7 +22,7 @@ setup(
         'pyvistaqt'
     ],
     url='https://github.com/cgre-aachen/gempy',
-    download_url='https://github.com/cgre-aachen/gempy/archive/2.1.1tar.gz',
+    download_url='https://github.com/cgre-aachen/gempy/archive/2.2.1.tar.gz',
     license='LGPL v3',
     author='Miguel de la Varga, Elisa Heim, Alexander Schaaf, Fabian Stamm, Florian Wellmann',
     author_email='varga@aices.rwth-aachen.de',


### PR DESCRIPTION
importing the package to get the version of the software is not a good practice, because tools that need to run the setup.py script need to have all runtime dependencies installed at "install time" which isn't a great assumption to make.

# Description
Please include a summary of the changes.

Relates to #436 

# Checklist
- [ ] My code follows the [PEP 8 style guidelines](https://www.python.org/dev/peps/pep-0008/).
- [ ] My code uses type hinting for function and method arguments and return values.
- [ ] My code contains descriptive and helpful docstrings 
which are formatted per the [Google Python Style Guidelines](http://google.github.io/styleguide/pyguide.html).
- [ ] I have created tests which entirely cover my code.
- [ ] The test code either 1. demonstrates at least one valuable use case (e.g. integration tests) 
or 2. verifies that outputs are as expected for given inputs (e.g. unit tests).
- [ ] New and existing tests pass locally with my changes.
 
