### PR TITLE
Fix Travis for emg3d/pymc3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: python
-
+os: linux
 dist: xenial
 
 python:
   - '3.7'
-
-env: TRAVIS=true
 
 before_install:
   # configure a headless display
@@ -13,31 +11,33 @@ before_install:
   - source ./gl-ci-helpers/travis/setup_headless_display.sh
 
 install:
-  - wget https://repo.anaconda.com/pkgs/misc/conda-execs/conda-latest-linux-64.exe -O conda.exe
-  - chmod +x conda.exe
-  - export CONDA_ALWAYS_YES=1
-  # This is where you put any extra dependencies you may have.
-  - ./conda.exe create -p $HOME/miniconda python=$TRAVIS_PYTHON_VERSION conda conda-build pytest six pytest-cov pytest-mock
+  - sudo apt-get update
+  # We do this conditionally because it saves us some downloading if the
+  # version is the same.
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+  - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
-  - pip install --upgrade setuptools pip
-  - pip install -r requirements.txt
-  - pip install sphinx-gallery
-  - pip install qgrid
-  - pip install nbval
-  - pip install pyevtk
-  - pip install arviz
-  - pip install recommonmark
-  - pip install dataclasses pyvista panel discretize # emg3d
-  - pip install welly
-  - conda install gdal
-  - conda install --yes -c conda-forge python-graphviz
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update --all
+  # Useful for debugging any issues with conda
+  - conda info -a
+
+  # Install and activate environment, install packages
+  - conda create -q -n tenv python=$TRAVIS_PYTHON_VERSION
+  - source activate tenv
+
+  # Installs from conda-forge
+  - conda install -c conda-forge python-graphviz emg3d discretize pip matplotlib ipython six pytest pytest-cov pytest-mock gdal pandas seaborn>=0.9 qgrid nbval sphinx-gallery ipywidgets pyevtk arviz dataclasses scikit-image>=0.17 recommonmark networkx panel setuptools
+
+  # Installs from anaconda
   - conda install -c anaconda libffi
-  - pip install pymc3
-  - pip install ipython
-    # Install untested, non-required code (linter fails without them)
-  - pip install ipython ipywidgets
-  - export PATH="./bin:$PATH"
+
+  # Installs from pip
+  - pip install pyvista welly pymc3
+
+  # Install
+  - pip install -e .
 
 script:
   - pytest -v notebooks/ --nbval-lax
@@ -57,7 +57,6 @@ jobs:
        # if: (NOT type IN (pull_request)) AND (branch = sphinx-gallery) # only deploy if merging on master
 
         before_script:
-         - pip install -e .
          - cd docs
         script: pipenv run make html
         deploy:
@@ -70,4 +69,3 @@ jobs:
           target_branch: gh-pages
           fqdn: docs.gempy.org
 cache: pip
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - source activate tenv
 
   # Installs from conda-forge
-  - conda install -c conda-forge python-graphviz emg3d discretize pip matplotlib ipython six pytest pytest-cov pytest-mock gdal pandas seaborn>=0.9 qgrid nbval sphinx-gallery ipywidgets pyevtk arviz dataclasses scikit-image>=0.17 recommonmark networkx panel setuptools
+  - conda install -c conda-forge python-graphviz emg3d discretize pip matplotlib ipython six pytest pytest-cov pytest-mock gdal pandas seaborn>=0.9 qgrid sphinx-gallery ipywidgets pyevtk arviz dataclasses scikit-image>=0.17 recommonmark networkx panel setuptools
 
   # Installs from anaconda
   - conda install -c anaconda libffi
@@ -38,10 +38,6 @@ install:
 
   # Install
   - pip install -e .
-
-script:
-  - pytest -v notebooks/ --nbval-lax
-  - pytest
 
 stages:
   - test

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -144,8 +144,6 @@ todo_include_todos = True
 
 
 # -- Sphinx Gallery Options
-from sphinx_gallery.sorting import FileNameSortKey
-
 sphinx_gallery_conf = {
     # path to your examples scripts
     "examples_dirs": [

--- a/examples/integrations/gempy_discretize_emg3d.py
+++ b/examples/integrations/gempy_discretize_emg3d.py
@@ -115,15 +115,18 @@ freq = 1.0  # Frequency
 
 # %% 
 # Get calculation domain as a function of frequency (resp., skin depth)
-hx_min, xdomain = emg3d.utils.get_domain(x0=src[0], freq=freq, limits=[0, 2000], min_width=[5, 100])
-hz_min, zdomain = emg3d.utils.get_domain(freq=freq, limits=[-2000, 0], min_width=[5, 20], fact_pos=40)
+hx_min, xdomain = emg3d.utils.get_domain(
+        x0=src[0], freq=freq, limits=[0, 2000], min_width=[5, 100])
+hz_min, zdomain = emg3d.utils.get_domain(
+        freq=freq, limits=[-2000, 0], min_width=[5, 20], fact_pos=40)
 
 # Create stretched grid
 nx = 2 ** 6
 hx = emg3d.utils.get_stretched_h(hx_min, xdomain, nx, src[0])
 hy = emg3d.utils.get_stretched_h(hx_min, xdomain, nx, src[1])
 hz = emg3d.utils.get_stretched_h(hz_min, zdomain, nx * 2, x0=src[2], x1=0)
-grid = discretize.TensorMesh([hx, hy, hz], x0=(xdomain[0], xdomain[0], zdomain[0]))
+grid = discretize.TensorMesh(
+        [hx, hy, hz], x0=(xdomain[0], xdomain[0], zdomain[0]))
 grid
 
 # %%
@@ -208,7 +211,7 @@ model = emg3d.utils.Model(grid, res)
 sfield = emg3d.utils.get_source_field(grid, src, freq, 0)
 
 # Calculate the efield
-pfield = emg3d.solver.solve(grid, model, sfield, sslsolver=True, verb=3)
+pfield = emg3d.solve(grid, model, sfield, sslsolver=True, verb=3)
 
 # %% 
 cgrid.plot_3d_slicer(


### PR DESCRIPTION
- Fix Travis to include the emg3d-example in the gallery.
- Slight overhaul of .travis.yml (mostly not touching the structure of it):
  - Using the default miniconda-approach instead of the bootstrapping approach (https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/use-conda-with-travis-ci.html).
  - Whenever possible getting package from conda-forge.
  - Using a conda-env.
  - Always installing gempy (before that was only done for 'deploy').
- Update emg3d-example to reflect changes in emg3d.
- Remove double entry ` from sphinx_gallery.sorting import FileNameSortKey ` in `docs/source/conf.py`.