### PR TITLE
Have Travis only check master, release, and PR branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: python
 os: linux
 dist: xenial
 
+branches:
+    only:
+        - master
+        - release
+
 python:
   - '3.7'
 


### PR DESCRIPTION
Before this change, Travis checks every commit pushed to every branch on gempy's GitHub repository.

Furthermore, making a new branch, even without adding new commits, causes Travis to check the latest commit on the new branch again (#467 ).

With this PR, I propose that Travis only checks the release and master branches. Since we have the following option enabled on the Travis side
![image](https://user-images.githubusercontent.com/9367569/86237802-bbe71f80-bb9c-11ea-9e68-826393fd3fd9.png)
all commits pushed to PR branches are still checked. This means that Travis starts testing changes as soon as there is a PR and not until then. I think that this is the ideal behavior.