### PR TITLE
🌈 Fix 451: Adds random color generation for more than 66 surfaces

### DIFF
--- a/gempy/core/data.py
+++ b/gempy/core/data.py
@@ -5,6 +5,7 @@ from typing import Union, List
 
 import numpy as np
 import pandas as pn
+import seaborn as sns
 
 try:
     import ipywidgets as widgets
@@ -281,76 +282,88 @@ class Colors:
     """
     Object that handles the color management in the model.
     """
-
     def __init__(self, surfaces):
         self.surfaces = surfaces
+        self.colordict = None
+        self._hexcolors_soft = [
+            '#015482', '#9f0052', '#ffbe00', '#728f02', '#443988',
+            '#ff3f20', '#5DA629', '#b271d0', '#72e54a', '#583bd1',
+            '#d0e63d', '#b949e2', '#95ce4b', '#6d2b9f', '#60eb91',
+            '#d746be', '#52a22e', '#5e63d8', '#e5c339', '#371970',
+            '#d3dc76', '#4d478e', '#43b665', '#d14897', '#59e5b8',
+            '#e5421d', '#62dedb', '#df344e', '#9ce4a9', '#d94077',
+            '#99c573', '#842f74', '#578131', '#708de7', '#df872f',
+            '#5a73b1', '#ab912b', '#321f4d', '#e4bd7c', '#142932',
+            '#cd4f30', '#69aedd', '#892a23', '#aad6de', '#5c1a34',
+            '#cfddb4', '#381d29', '#5da37c', '#d8676e', '#52a2a3',
+            '#9b405c', '#346542', '#de91c9', '#555719', '#bbaed6',
+            '#945624', '#517c91', '#de8a68', '#3c4b64', '#9d8a4d',
+            '#825f7e', '#2c3821', '#ddadaa', '#5e3524', '#a3a68e',
+            '#a2706b', '#686d56'
+        ]  # source: https://medialab.github.io/iwanthue/
 
-    def generate_colordict(self, hex_colors='palettes',
-                           palettes: List[str] = 'default', out=False):
-        """generate colordict that assigns black to faults and random colors to surfaces
+    def generate_colordict(
+            self,
+            hex_colors: Union[List[str], str] = 'palettes',
+            palettes: List[str] = 'default',
+    ):
+        """Generates and sets color dictionary.
 
         Args:
-           hex_colors (list[str], str): List of hex values or specific values. In the
-            future this could accommodate the actual geological palettes. For example
-            striplog has a quite good set of palettes.
+           hex_colors (list[str], str): List of hex color values. In the future this could
+           accommodate the actual geological palettes. For example striplog has a quite
+           good set of palettes.
                 * palettes: If hexcolors='palettes' the colors will be chosen from the
                    palettes arg
                 * soft: https://medialab.github.io/iwanthue/
-
-           palettes (list[str]): list with name of seaborn palettes
+           palettes (list[str], optional): list with name of seaborn palettes. Defaults to 'default'.
         """
-        import seaborn as sns
-
         if hex_colors == 'palettes':
             hex_colors = []
             if palettes == 'default':
+                # we predefine some 7 colors manually
                 hex_colors = ['#015482', '#9f0052', '#ffbe00', '#728f02', '#443988', '#ff3f20', '#5DA629']
+                # then we create a list of seaborn color palette names, as the user didn't provide any
                 palettes = ['muted', 'pastel', 'deep', 'bright', 'dark', 'colorblind']
-
-            for i in palettes:
-                s = sns.color_palette(i).as_hex()
-                hex_colors += s
+            for palette in palettes:  # for each palette
+                hex_colors += sns.color_palette(palette).as_hex()  # get all colors in palette and add to list
                 if len(hex_colors) >= len(self.surfaces.df):
                     break
         elif hex_colors == 'soft':
-            hex_colors = ['#015482', '#9f0052', '#ffbe00', '#728f02', '#443988',
-                          '#ff3f20', '#5DA629', '#b271d0', '#72e54a', '#583bd1',
-                          '#d0e63d', '#b949e2', '#95ce4b', '#6d2b9f', '#60eb91',
-                          '#d746be', '#52a22e', '#5e63d8', '#e5c339', '#371970',
-                          '#d3dc76', '#4d478e', '#43b665', '#d14897', '#59e5b8',
-                          '#e5421d', '#62dedb', '#df344e', '#9ce4a9', '#d94077',
-                          '#99c573', '#842f74', '#578131', '#708de7', '#df872f',
-                          '#5a73b1', '#ab912b', '#321f4d', '#e4bd7c', '#142932',
-                          '#cd4f30', '#69aedd', '#892a23', '#aad6de', '#5c1a34',
-                          '#cfddb4', '#381d29', '#5da37c', '#d8676e', '#52a2a3',
-                          '#9b405c', '#346542', '#de91c9', '#555719', '#bbaed6',
-                          '#945624', '#517c91', '#de8a68', '#3c4b64', '#9d8a4d',
-                          '#825f7e', '#2c3821', '#ddadaa', '#5e3524', '#a3a68e',
-                          '#a2706b', '#686d56']
+            hex_colors = self._hexcolors_soft
 
-        colordict = dict(zip(list(self.surfaces.df['surface']), hex_colors[:len(self.surfaces.df)]))
-        self.colordict = colordict
-        return colordict
+        surface_names = self.surfaces.df['surface'].values
+        n_surfaces = len(surface_names)
 
-    def change_colors(self, cdict=None):
-        ''' Updates the colors of the model.
+        while n_surfaces > len(hex_colors):
+            hex_colors.append(self._random_hexcolor())
+
+        self.colordict = dict(
+            zip(surface_names, hex_colors[:n_surfaces])
+        )
+
+    @staticmethod
+    def _random_hexcolor() -> str:
+        """Generates a random hex color string."""
+        return "#"+str(hex(np.random.randint(0, 16777215))).lstrip("0x")
+
+    def change_colors(self, colordict: dict = None):
+        """Change the model colors either by providing a color dictionary or,
+        if not, by using a color pick widget.
+
         Args:
-            cdict: dict with surface names mapped to hex color codes, e.g. {'layer1':'#6b0318'}
-            if None: opens jupyter widget to change colors interactively.
-
-        Returns: None
-
-        '''
+            colordict (dict, optional): dict with surface names mapped to hex color codes, e.g. {'layer1':'#6b0318'}
+            if None: opens jupyter widget to change colors interactively. Defaults to None.
+        """
         assert ipywidgets_import, 'ipywidgets not imported. Make sure the library is installed.'
 
-        if cdict is not None:
-            self.update_colors(cdict)
-            return self.surfaces
-
+        if colordict:
+            self.update_colors(colordict)
         else:
-            items = [widgets.ColorPicker(description=surface, value=color)
-                     for surface, color in self.colordict.items()]
-
+            items = [
+                widgets.ColorPicker(description=surface, value=color)
+                for surface, color in self.colordict.items()
+            ]
             colbox = widgets.VBox(items)
             print('Click to select new colors.')
             display(colbox)
@@ -362,22 +375,17 @@ class Colors:
             for cols in colbox.children:
                 cols.observe(on_change, 'value')
 
-    def update_colors(self, cdict=None):
-        ''' Updates the colors in self.colordict and in surfaces_df.
+    def update_colors(self, colordict: dict = None):
+        """ Updates the colors in self.colordict and in surfaces_df.
+
         Args:
-            cdict: dict with surface names mapped to hex color codes, e.g. {'layer1':'#6b0318'}
-
-        Returns: None
-
-        '''
-        if cdict is None:
-            # assert if one surface does not have color
-            try:
-                self._add_colors()
-            except AttributeError:
-                self.generate_colordict()
+            colordict (dict, optional): dict with surface names mapped to hex
+                color codes, e.g. {'layer1':'#6b0318'}. Defaults to None.
+        """
+        if colordict is None:
+            self.generate_colordict()
         else:
-            for surf, color in cdict.items():  # map new colors to surfaces
+            for surf, color in colordict.items():  # map new colors to surfaces
                 # assert this because user can set it manually
                 assert surf in list(self.surfaces.df['surface']), str(surf) + ' is not a model surface'
                 assert re.search(r'^#(?:[0-9a-fA-F]{3}){1,2}$', color), str(color) + ' is not a HEX color code'
@@ -386,15 +394,11 @@ class Colors:
         self._set_colors()
 
     def _add_colors(self):
-        '''assign color to last entry of surfaces df or check isnull and assign color there'''
-        # can be done easier
-        new_colors = self.generate_colordict()
-        form2col = list(self.surfaces.df.loc[self.surfaces.df['color'].isnull(), 'surface'])
-        # this is the dict in-build function to update colors
-        self.colordict.update(dict(zip(form2col, [new_colors[x] for x in form2col])))
+        """Assign a color to the last entry of surfaces df or check isnull and assign color there"""
+        self.generate_colordict()
 
     def _set_colors(self):
-        '''sets colordict in surfaces dataframe'''
+        """sets colordict in surfaces dataframe"""
         for surf, color in self.colordict.items():
             self.surfaces.df.loc[self.surfaces.df['surface'] == surf, 'color'] = color
 

--- a/test/test_core/test_colors.py
+++ b/test/test_core/test_colors.py
@@ -1,0 +1,10 @@
+import gempy as gp
+import numpy as np
+
+
+def test_colors_101_surfaces():
+    """Tests if GemPy Colors class works with at least 101 surfaces."""
+    geomodel = gp.create_model("ColorfulModel")
+    for n in range(101):
+        geomodel.add_surfaces(f"Surface {n}")
+    assert np.all(geomodel.surfaces.df.color.values != np.nan)


### PR DESCRIPTION
# Description
Adds random hexcolor generation to the surface color dict generation to avoid problems with too many surfaces (so far 66 was the maximum).

Fixes #451 

Supersedes #462 and #452 .

I am expecting the Travis check to fail at first because of #461. There might be a bug in the changes to the Color class which will be difficult to track down given the error messages we've seen so far.

# Checklist
- [x] My code follows the [PEP 8 style guidelines](https://www.python.org/dev/peps/pep-0008/).
- [x] My code uses type hinting for function and method arguments and return values.
- [x] My code contains descriptive and helpful docstrings 
which are formatted per the [Google Python Style Guidelines](http://google.github.io/styleguide/pyguide.html).
- [x] I have created tests which entirely cover my code.
- [x] The test code either 1. demonstrates at least one valuable use case (e.g. integration tests) 
or 2. verifies that outputs are as expected for given inputs (e.g. unit tests).
- [x] New and existing tests pass locally with my changes.
 
