### PR TITLE
Freeze pandas version because of bug in 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   # Installs from conda-forge
   - conda install -c conda-forge python-graphviz emg3d==0.11
     discretize==0.4.13 pip matplotlib ipython six pytest pytest-cov
-    pytest-mock gdal pandas seaborn>=0.9 qgrid sphinx-gallery
+    pytest-mock gdal pandas==1.0.5 seaborn>=0.9 qgrid sphinx-gallery
     ipywidgets pyevtk arviz dataclasses scikit-image>=0.17
     recommonmark networkx panel setuptools mkl-service
 


### PR DESCRIPTION
Fixes #502 by freezing the version of pandas installed by Travis to pandas==1.0.5.

This should be a temporary fix. Ideally we will be able to install the latest pandas on master and only freeze versions for releases.

So far I have had trouble writing a MWE for raising a proper issue at the pandas repo. See #502 for progress.

- [x] Existing tests pass locally with my changes.
 
