### PR TITLE
Remove pandas version restriction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   # Installs from conda-forge
   - conda install -c conda-forge python-graphviz emg3d==0.11
     discretize==0.4.13 pip matplotlib ipython six pytest pytest-cov
-    pytest-mock gdal pandas==1.0.5 seaborn>=0.9 qgrid sphinx-gallery
+    pytest-mock gdal pandas seaborn>=0.9 qgrid sphinx-gallery
     ipywidgets pyevtk arviz dataclasses scikit-image>=0.17
     recommonmark networkx panel setuptools mkl-service
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas<=1.0.5
+pandas
 Theano>=1.0.4 # In windows use conda! This will install all the required compilers
 matplotlib
 numpy


### PR DESCRIPTION
We restricted the pandas version to fix #502. @AndrewAnnex asked if the issue persists in pandas 1.1.1. 

Related: In #506 we are discussing how to better handle such dependencies.