### PR TITLE
[WIP] Remove Travis's re-install of exact PyVista version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,6 @@ install:
 
   # Install
   - pip install -e .
-  # foo
-  - pip install pyvista==0.24.3 --force-reinstall
 
   - python -c "import pyvista as pv;print(pv.Report())"
 


### PR DESCRIPTION
Per the latest discussion in #491 , this PR removes the PyVista version restriction from Travis's installation.

Note that `requirements.txt` still has a comment saying "0.24 and 0.25 compatible".

This should also be cleaned up as part of #506 .