### PR TITLE
Have Travis pip install PyVista master from GitHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,12 +44,11 @@ install:
 
   # Installs from pip
   - pip install welly pymc3 pooch
-
+  - pip install git+https://github.com/pyvista/pyvista.git@master
+  
   # Install
   - pip install -e .
-  # foo
-  - pip install pyvista==0.24.3 --force-reinstall
-
+  
   - python -c "import pyvista as pv;print(pv.Report())"
 
 stages:


### PR DESCRIPTION
Investigating for #491.

This version of `.travis.yml` also installs PyVista *before* GemPy rather than how our master version installs PyVista (with a forced reinstall) *after* GemPy.

This PR should not be merged; but we want Travis to test it here.