### PR TITLE
'RemoveCollections'

### DIFF
--- a/gempy/core/interpolator.py
+++ b/gempy/core/interpolator.py
@@ -1,4 +1,3 @@
-from collections import Iterable
 from typing import Union
 from gempy.core.data import Grid, Surfaces, AdditionalData
 from gempy.core.data_modules.geometric_data import SurfacePoints, Orientations


### PR DESCRIPTION
Got another warning in my tests, this time:

`../......lib/python3.9/site-packages/gempy/core/interpolator.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    from collections import Iterable`

However, `from collections import Iterable` is not even used in `interpolator.py` as all occurrences are currently commented (lines 157-166, lines 180-190).

Cheers Alex

