### PR TITLE
Do not merge yet - FixPandasIssue

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,7 @@
 [![Travis Build](https://travis-ci.org/cgre-aachen/gempy.svg?branch=master)](https://travis-ci.org/github/cgre-aachen/gempy/branches)
 [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/cgre-aachen/gempy/master)
 [![DOI](https://zenodo.org/badge/96211155.svg)](https://zenodo.org/badge/latestdoi/96211155)
-[![DOCKER](https://img.shields.io/docker/cloud/automated/leguark/gempy.svg)](https://cloud.docker.com/repository/docker/leguark/gempy)
-
-:warning: **Warning: GemPy requires pandas version < 1.4.0. The new pandas release is not compatible with GemPy.  
-    We're actively working on this issue for a future release.  
-Please make sure to use Pandas version 1.3.x when working with GemPy for the time being.** 
+[![DOCKER](https://img.shields.io/docker/cloud/automated/leguark/gempy.svg)](https://cloud.docker.com/repository/docker/leguark/gempy) 
 
 **Using theano, GemPy requires numpy version < 1.22.0 as `blas_opt_info` was deprecated in newer numpy versions.**:warning:
 ## Overview

--- a/gempy/__init__.py
+++ b/gempy/__init__.py
@@ -38,9 +38,6 @@ from gempy.plot.plot_api import plot_2d, plot_3d
 from gempy.plot import _plot as _plot
 
 assert sys.version_info[0] >= 3, "GemPy requires Python 3.X"  # sys.version_info[1] for minor e.g. 6
-assert pandas.__version__ <= '1.4.0', \
-    "GemPy requires pandas version < 1.4.0. The new pandas release is not compatible with GemPy.\n" \
-    "We're actively working on this issue for a future release.\n"
 
 __version__ = '2.2.12'
 

--- a/gempy/core/data_modules/stack.py
+++ b/gempy/core/data_modules/stack.py
@@ -215,8 +215,7 @@ class Series(object):
         """
         Reset the column order series to monotonic ascendant values.
         """
-        # self.df['order_series'] = pn.RangeIndex(1, self.df.shape[0] + 1) pandas 1.4 change
-        self.df.at[:, 'order_series'] = pn.RangeIndex(1, self.df.shape[0] + 1) # pandas 1.3 version
+        self.df['order_series'] = np.arange(1, self.df.shape[0] + 1)
 
     @_setdoc_pro(reset_order_series.__doc__)
     def set_series_index(self, series_order: Union[list, np.ndarray], reset_order_series=True):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ setup(
     packages=find_packages(exclude=('test', 'docs', 'examples')),
     include_package_data=True,
     install_requires=[
-        'pandas==1.3.4',
         'Theano>=1.0.4',
         'matplotlib',
         'numpy==1.21.6',


### PR DESCRIPTION
# Description
This PR should fix the known Pandas issue and allow for installing the latest version of Pandas (currently 1.5.2)

The issue was in stack.py (line 219) where a RangeIndex was created to reorder the series. This could not be assigned in recent Pandas versions anymore. It was therefore replaced with `np.arange()`.

```ruby
    def reset_order_series(self):
        """
        Reset the column order series to monotonic ascendant values.
        """
       [...]
        self.df.at[:, 'order_series'] = pn.RangeIndex(1, self.df.shape[0] + 1) # pandas 1.3 version

```