### PR TITLE
Minor change: reset dataframe index for input data

### DIFF
--- a/gempy/core/model.py
+++ b/gempy/core/model.py
@@ -991,7 +991,10 @@ class ImplicitCoKriging(object):
             :class:`gempy.core.data_modules.geometric_data.SurfacePoints`
 
         """
-
+        if isinstance(table,pn.DataFrame):
+            table = table.reset_index(drop=True)
+        else:
+            raise ValueError('Input must be Pandas Dataframe')
         try:
             coord_x_name = kwargs.get('coord_x_name') if 'coord_x_name' in kwargs \
                 else self._check_possible_column_names(table, ['X', 'x'])
@@ -1049,6 +1052,10 @@ class ImplicitCoKriging(object):
             :class:`gempy.core.data_modules.geometric_data.Orientations`
 
         """
+        if isinstance(table,pn.DataFrame):
+            table = table.reset_index(drop=True)
+        else:
+            raise ValueError('Input must be Pandas Dataframe')
         g_x_name = kwargs.get('G_x_name', 'G_x')
         g_y_name = kwargs.get('G_y_name', 'G_y')
         g_z_name = kwargs.get('G_z_name', 'G_z')


### PR DESCRIPTION
# Description
Reset input Pandas df index when loading dataframe from `init_data()`

Currently if loading data from dataframe which has duplicated index, pandas will return indexing error. This fix indexing and make copy of the input dataframe (To maintain immutability of user input data)

# Checklist
- [x ] My code follows the [PEP 8 style guidelines](https://www.python.org/dev/peps/pep-0008/).
- [n/a] My code uses type hinting for function and method arguments and return values.
- [n/a] My code contains descriptive and helpful docstrings 
which are formatted per the [Google Python Style Guidelines](http://google.github.io/styleguide/pyguide.html).
- [n/a] I have created tests which entirely cover my code.
- [n/a] The test code either 1. demonstrates at least one valuable use case (e.g. integration tests) 
or 2. verifies that outputs are as expected for given inputs (e.g. unit tests).
- [n/a] New and existing tests pass locally with my changes.
 
