### PR TITLE
[BUG] surface points added to wrong surface

### DIFF
--- a/gempy/core/data_modules/geometric_data.py
+++ b/gempy/core/data_modules/geometric_data.py
@@ -162,7 +162,7 @@ class GeometricData(object):
     def _add_surface_to_list_from_new_surface_points_or_orientations(self, idx, surface: list | str):
         if type(surface) is str: surface = [surface]
         
-        # Check is self.df['surface'] is a category
+        # Check if self.df['surface'] is a category
         if not isinstance(self.df['surface'].dtype, pd.CategoricalDtype):
             self.df['surface'] = self.df['surface'].astype('category', copy=True)
             self.df['surface'] = self.df['surface'].cat.set_categories(self.surfaces.df['surface'].values)
@@ -172,7 +172,7 @@ class GeometricData(object):
         #     if s not in self.df['surface'].cat.categories:
         #         self.df['surface'] = self.df['surface'].cat.add_categories(s)
 
-        if type(idx) is int:
+        if isinstance(idx, (np.int64, int)):
             self.df.loc[idx, 'surface'] = surface[0]
         elif type(idx) is list:
             self.df.loc[idx, 'surface'] = surface

--- a/test/test_core/test_data_mutation.py
+++ b/test/test_core/test_data_mutation.py
@@ -6,6 +6,7 @@ import gempy as gp
 import numpy as np
 import pytest
 import os
+import matplotlib.pyplot as plt
 
 mm = gp.ImplicitCoKriging()
 mm.add_surfaces(['surface1', 'foo1', 'foo2', 'foo3'])
@@ -94,3 +95,19 @@ def test_read_data():
                     path_o=data_path + "/data/input_data/tut_chapter1/simple_fault_model_orientations.csv")
 
     assert model._surface_points.df.shape[0] == 57
+
+def test_add_surface_points_to_model():
+    geo_model = gp.create_model('TestModel1')
+    gp.init_data(geo_model, extent=[0, 800, 0, 200, -600, 0], resolution=[100, 100, 100])
+    geo_model.set_default_surfaces()
+
+    geo_model.add_surface_points(X=223, Y=0.01, Z=-94, surface='surface1')
+    geo_model.add_surface_points(X=458, Y=0, Z=-107, surface='surface1')
+    geo_model.add_surface_points(X=612, Y=0, Z=-14, surface='surface1')
+    geo_model.add_orientations(X=350, Y=0, Z=-300, surface='surface1', pole_vector=(0, 0, 1))
+
+    geo_model.add_surface_points(X=225, Y=1, Z=-269, surface='surface2')
+    geo_model.add_surface_points(X=459, Y=1, Z=-279, surface='surface2')
+
+    #gp.plot_2d(geo_model, cell_number=5, legend='force')
+    #plt.show()


### PR DESCRIPTION
# Description
Manually added surface points with `add_surface_points` were allocated to the first created surface.
This was due to a type check solely for `int`. Changed to `isinstance(idx, (int, np.int64))` as somewhere along the creation, `idx` gets changed from `int` to `np.int64`...

Relates to #813 

# Checklist
- [x] My code follows the [PEP 8 style guidelines](https://www.python.org/dev/peps/pep-0008/).
- [ ] My code uses type hinting for function and method arguments and return values.
- [ ] My code contains descriptive and helpful docstrings 
which are formatted per the [Google Python Style Guidelines](http://google.github.io/styleguide/pyguide.html).
- [x] I have created tests which entirely cover my code.
- [x] The test code either 1. demonstrates at least one valuable use case (e.g. integration tests) 
or 2. verifies that outputs are as expected for given inputs (e.g. unit tests).
- [x] New and existing tests pass locally with my changes.
 
