### PR TITLE
[WIP] FixFontSize

### DIFF
--- a/gempy/plot/plot_api.py
+++ b/gempy/plot/plot_api.py
@@ -278,7 +278,7 @@ def plot_3d(model, plotter_type='basic',
             kwargs_plot_data=None,
             image=False,
             off_screen=False,
-            font_size: int =pv.global_theme.font.size,
+            font_size: int = pv.global_theme.font.size,
             **kwargs) -> GemPyToVista:
     """foobar
 

--- a/gempy/plot/plot_api.py
+++ b/gempy/plot/plot_api.py
@@ -277,7 +277,9 @@ def plot_3d(model, plotter_type='basic',
             kwargs_plot_topography=None,
             kwargs_plot_data=None,
             image=False,
-            off_screen=False, **kwargs) -> GemPyToVista:
+            off_screen=False,
+            font_size: int =pv.global_theme.font.size,
+            **kwargs) -> GemPyToVista:
     """foobar
 
     Args:
@@ -297,6 +299,8 @@ def plot_3d(model, plotter_type='basic',
         ve (float): Vertical Exaggeration
         kwargs_plot_structured_grid:
         kwargs_plot_topography:
+        font_size : int
+            Font size for the labels of the grid
         **kwargs:
 
     Returns:

--- a/gempy/plot/plot_api.py
+++ b/gempy/plot/plot_api.py
@@ -338,6 +338,9 @@ def plot_3d(model, plotter_type='basic',
     if ve is not None:
         gpv.p.set_scale(zscale=ve)
 
+    if font_size is not None:
+        gpv.p.show_bounds(font_size=font_size)
+
     if fig_path is not None:
         gpv.p.show(screenshot=fig_path)
 


### PR DESCRIPTION
# Description
Allows the user to change the font size of the grid labels when `ve=1` by using `gp.plot_3d(geo_model, ... , font_size=12)`. **When `ve` other than `1` is applied, the label size cannot be changed for some reason.** I assume it is a PyVista-related bug as I can reproduce it with a minimal code example. Bug report in the PyVista at https://github.com/pyvista/pyvista/issues/4768

Relates to https://github.com/cgre-aachen/gempy/discussions/818
