### PR TITLE
FixOrientationdf

### DIFF
--- a/gempy/core/data_modules/orientations.py
+++ b/gempy/core/data_modules/orientations.py
@@ -37,7 +37,8 @@ class Orientations(GeometricData):
                                'surface', 'series', 'id', 'order_series', 'surface_number']
         self._columns_o_1 = ['X', 'Y', 'Z', 'X_c', 'Y_c', 'Z_c', 'G_x', 'G_y', 'G_z', 'dip', 'azimuth', 'polarity',
                              'surface', 'series', 'id', 'order_series', 'isFault']
-        self._columns_o_num = ['X', 'Y', 'Z', 'X_c', 'Y_c', 'Z_c', 'G_x', 'G_y', 'G_z', 'dip', 'azimuth', 'polarity']
+        self._columns_o_num = ['X', 'Y', 'Z', 'X_c', 'Y_c', 'Z_c', 'G_x', 'G_y', 'G_z', 'dip', 'azimuth', 'polarity', 
+                               'surface']
         self._columns_rend = ['X', 'Y', 'Z', 'G_x', 'G_y', 'G_z', 'smooth', 'surface']
 
         if (np.array(sys.version_info[:2]) <= np.array([3, 6])).all():

--- a/gempy/core/model.py
+++ b/gempy/core/model.py
@@ -1809,7 +1809,7 @@ class Project(ImplicitCoKriging):
             if numeric:
                 raw_data = raw_data[
                     ['X', 'Y', 'Z', 'G_x', 'G_y', 'G_z', 'dip', 'azimuth',
-                     'polarity']]
+                     'polarity', 'surface']]
         elif itype == 'surface_points' or itype == 'surface points':
             raw_data = self._surface_points.df[show_par_i]  # .astype(dtype)
             # Be sure that the columns are in order when used for operations


### PR DESCRIPTION
# Description
This PR adds the column 'surface' to the result of `gp.get_data(geo_model, 'orientations', numeric=True)`. This way, it becomes easier to filter points by surfaces. If `numeric=False`, the dip and azimuth values are not provided. 

![image](https://github.com/cgre-aachen/gempy/assets/45469915/1e91bcfa-9baf-4a9c-9add-8ebd9feae1e6)

A quick merge and patch release would be appreciated since I need this for my little hack for finite faults ;) 

Relates to #821

# Checklist
- [ ] My code follows the [PEP 8 style guidelines](https://www.python.org/dev/peps/pep-0008/).
- [ ] My code uses type hinting for function and method arguments and return values.
- [ ] My code contains descriptive and helpful docstrings 
which are formatted per the [Google Python Style Guidelines](http://google.github.io/styleguide/pyguide.html).
- [ ] I have created tests which entirely cover my code.
- [ ] The test code either 1. demonstrates at least one valuable use case (e.g. integration tests) 
or 2. verifies that outputs are as expected for given inputs (e.g. unit tests).
- [ ] New and existing tests pass locally with my changes.
 
